### PR TITLE
include maven and build in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 FROM cloudesire/java:8
 
-ADD target/appassembler /opt/confyrm/demo/
+RUN  \
+  export DEBIAN_FRONTEND=noninteractive && \
+  apt-get update && \
+  apt-get install -y maven
+
+ADD . /opt/confyrm/build
+
+WORKDIR /opt/confyrm/build
+
+RUN mvn clean package
+RUN mv target/appassembler /opt/confyrm/demo
 
 WORKDIR  /opt/confyrm/demo
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,6 @@
 
 ## Build
 
-* Build application: `mvn clean package`
 * Build docker image: `sudo scripts/build_docker_image.sh`
 
 ## Configure


### PR DESCRIPTION
I ran into an issue building the project on my host machine.
This pull request makes it possible to build the demo app inside the docker eliminating java/mnv requirements on the host machine.